### PR TITLE
Fix yaml indent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ cache:
     - $HOME/.m2/repository
 
 after_success:
-- ./scripts/deploy_codox.sh
+  - ./scripts/deploy_codox.sh


### PR DESCRIPTION
We think this is breaking the codox deploy.
cc @zendesk/prism 