### PR TITLE
Fix travis to deploy docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 sudo: false
 language: clojure
-script: ./scripts/run_ci.sh
 branches:
   only:
     - master
 jdk:
   - oraclejdk8
-env:
-  matrix:
-    - CI_PART=unit
-    - CI_PART=eastwood
+jobs:
+  include:
+    - stage: test
+      script: CI_PART=unit ./scripts/run_ci.sh
+    -
+      script: CI_PART=eastwood ./scripts/run_ci.sh
+    - stage: deploy
+      script: ./scripts/deploy_codox.sh
 cache:
   timeout: 259200 # 3 days
   directories:
     - $HOME/.m2/repository
-
-after_success:
-  - ./scripts/deploy_codox.sh

--- a/scripts/deploy_codox.sh
+++ b/scripts/deploy_codox.sh
@@ -16,7 +16,7 @@ git config user.email "travis_ci@zendesk.com"
 
 rm -rf target/doc
 mkdir -p target
-git clone https://github.com/zendesk/clj-headlights target/doc
+git clone git@github.com:zendesk/clj-headlights.git target/doc
 cd target/doc
 git checkout gh-pages
 rm -rf ./*


### PR DESCRIPTION
Fix 2 issues with Travis:

1. Use SSH instead of HTTP for cloning repo
2. Run scripts in stages because `after_success` runs after every suite