### PR TITLE
Don't fail if new docs are the same

### DIFF
--- a/scripts/deploy_codox.sh
+++ b/scripts/deploy_codox.sh
@@ -28,7 +28,6 @@ cd ../..
 lein codox
 cd target/doc
 git add .
-git commit -am "New documentation for $TRAVIS_COMMIT"
-
-git push origin gh-pages
+git commit -am "New documentation for $TRAVIS_COMMIT" || true
+git push origin gh-pages || true
 cd ../..


### PR DESCRIPTION
During the Travis codox generation step, if docs don't change, git commit
and git push returns a non-zero exit code, which makes the script fail
because of set -e. This change makes it continue as if nothing happened.