### PR TITLE
Do not convert bigtable values to string

### DIFF
--- a/src/clj_headlights/bigtable_io.clj
+++ b/src/clj_headlights/bigtable_io.clj
@@ -67,7 +67,7 @@
 (defn get-cells-data
   [cell-list]
   (map (fn [^Cell cell]
-         {:value (-> cell .getValue .toStringUtf8)
+         {:value (-> cell .getValue)
           :timestamp-micro (.getTimestampMicros cell)})
        cell-list))
 


### PR DESCRIPTION
We should let the end-user figure out what to do with the bigtable bytes, for example a lot of the time in link these bytes are going to be nippy-serialized bytes.