### PR TITLE
Do not augment token mismatch exceptions

### DIFF
--- a/src/clj_headlights/clj_fn_call.clj
+++ b/src/clj_headlights/clj_fn_call.clj
@@ -40,7 +40,9 @@
   (try
     (apply (var-get (find-var full-name)) (into (vec args) params))
     (catch Exception e
-      (if (or (= 'clj-headlights.pardo ns-name) (= "class com.google.cloud.dataflow.worker.runners.worker.KeyTokenInvalidException" (str (class (.getCause e)))))
+      (if (or (= 'clj-headlights.pardo ns-name)
+              (= "class com.google.cloud.dataflow.worker.runners.worker.KeyTokenInvalidException" (str (class (.getCause e))))
+              (.startsWith (str (.getCause e)) "Unable to fetch data due to token mismatch for key"))
         (throw e)
         (do
           (log/error "An exception happened, here is some extra information" (ex-info (str "Exception in " full-name) {:creation-stack creation-stack :params params :data args} e))


### PR DESCRIPTION
Those exceptions occur when Dataflow is spinning up new workers and
re-balancing the work. Adding all the extra info is useless and creates a
lot of noise in the logs.