### PR TITLE
Warn when NippyCoder encodes large objects

### DIFF
--- a/src/clj_headlights/nippy.clj
+++ b/src/clj_headlights/nippy.clj
@@ -15,8 +15,14 @@
     (.read stream payload)
     (thaw payload)))
 
-(defn fast-encode-stream [^OutputStream stream data]
+(defn ^Integer fast-encode-stream
+  "Encode the given data with nippy, write the length of the resulting byte
+   array on the stream as an integer, then write the serialized data. Returns
+   the number of bytes written."
+  [^OutputStream stream data]
   (let [daos (DataOutputStream. stream)
-        bytes ^"[B" (freeze data)]
-    (.writeInt daos (alength bytes))
-    (.write daos bytes)))
+        bytes ^"[B" (freeze data)
+        bytes-count (alength bytes)]
+    (.writeInt daos bytes-count)
+    (.write daos bytes)
+    (+ 4 bytes-count)))


### PR DESCRIPTION
This change puts in place a warning message triggered when a NippyCoder
instance generates more than a given threshold of bytes (defaults to 100MB
as recommended by Google). This should help avoid bugs resulting in writing
very large objects to PCollections and the State API.