### PR TITLE
Print data in exception instead of to-s

### DIFF
--- a/src/clj_headlights/clj_fn_call.clj
+++ b/src/clj_headlights/clj_fn_call.clj
@@ -45,7 +45,7 @@
               (.startsWith (.getMessage (.getCause e)) "Unable to fetch data due to token mismatch for key"))
         (throw e)
         (do
-          (log/error "An exception happened, here is some extra information" (ex-info (str "Exception in " full-name) {:creation-stack creation-stack :params params :data args} e))
+          (log/error "An exception happened, here is some extra information" (ex-info (str "Exception in " full-name) {:creation-stack creation-stack :params params :data (mapv pr-str args)} e))
           (throw e))))))
 
 (s/defn serializable-function :- CljSerializableFunction


### PR DESCRIPTION
Using regular print makes it harder to play with the data in a clojure repl after copy/paste