### PR TITLE
update bigtable to use new config style

### DIFF
--- a/test/clj_headlights/t_bigtable_io.clj
+++ b/test/clj_headlights/t_bigtable_io.clj
@@ -7,7 +7,7 @@
 (deftest options-builder
   (testing "builds bigtable options"
     (is (= BigtableOptions$Builder
-           (class (bigtable-io/options-builder "project" "instance" "agent"))))))
+           (class (bigtable-io/options-builder "project" "instance" "agent" (BigtableOptions$Builder.)))))))
 
 (deftest mutation-builder
   (testing "turns a clojure map into a mutation"


### PR DESCRIPTION
Updating Beam to 2.8 caused a deprecation error in the BigTable code. I don't have an environment to test BigTable in but the tests pass and I think the change is right. 

Can you also publish a release? I am looking to use some features in 2.8. 

I love the library and I will have some more PRs to add features. 